### PR TITLE
Update Deno Standard Path Library NPM dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,11 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@parcel/packager-ts": "^2.16.0",
+    "@parcel/transformer-typescript-types": "^2.16.0",
     "eslint": "^9.32.0",
-    "parcel": "^2.15.4",
-    "rollup": "^4.46.2",
+    "parcel": "^2.16.0",
+    "rollup": "^4.52.5",
     "rollup-plugin-dts": "^6.2.1",
     "rollup-plugin-esbuild": "^6.2.1",
     "typedoc": "^0.27.9",
@@ -64,9 +66,12 @@
   },
   "dependencies": {
     "@happy-ts/fetch-t": "^1.3.2",
-    "@std/path": "npm:@jsr/std__path@^1.1.1",
+    "@std/path": "npm:@themartiancompany/std__path@^1.1.1",
+    "dist": "^0.1.2",
+    "dlx": "^0.2.1",
     "fflate": "^0.8.2",
     "happy-rusty": "^1.5.0",
+    "rimraf": "^6.1.0",
     "tiny-future": "^1.1.0",
     "tiny-invariant": "^1.3.3"
   },


### PR DESCRIPTION
Hello,

I've updated the `@std/path` dependency as mentioned in #5 making it point to
[`@themartiancopmany/std__path`](
  https://www.npmjs.com/package/@themartiancompany/std__path).